### PR TITLE
chore: update nginx config for cloud run

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -25,6 +25,7 @@ RUN npm run build
 FROM nginx:stable-alpine
 
 COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx/nginx.conf /etc/nginx/nginx.conf
 
-EXPOSE 80
+EXPOSE 8080
 CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -5,25 +5,14 @@ http {
     default_type  application/octet-stream;
 
     server {
-        listen 80;
+        listen 8080;
         server_name localhost;
-        return 301 https://$host$request_uri;
-    }
-
-    server {
-        listen 443 ssl;
-        server_name localhost;
-
-        ssl_certificate     /etc/nginx/ssl/cert.pem;
-        ssl_certificate_key /etc/nginx/ssl/privkey.pem;
-        ssl_protocols       TLSv1.2 TLSv1.3;
-        ssl_ciphers         HIGH:!aNULL:!MD5;
 
         root /usr/share/nginx/html;
         index index.html;
 
         location /api/ {
-            proxy_pass http://backend-prod:3000/api/;
+            proxy_pass https://transcendence-back-923872734712.europe-west6.run.app/api/;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection 'upgrade';
@@ -32,7 +21,7 @@ http {
         }
 
         location /ws/ {
-            proxy_pass http://backend-prod:3000/ws/;
+            proxy_pass https://transcendence-back-923872734712.europe-west6.run.app/ws/;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";


### PR DESCRIPTION
## Summary
- collapse Nginx into a single 8080 server and proxy to the HTTPS backend
- bake nginx.conf into the frontend image for Cloud Run deployment
- point API and WebSocket proxy to the deployed backend service

## Testing
- `npm run build` (frontend)
- `docker build -f frontend/Dockerfile . -t frontend:test` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68b6183c85d0833295a40a653d8e31e6