### PR TITLE
Parameterize API test HTTP file

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,11 @@ curl -X POST http://localhost:3000/api/match/<MATCH_ID>/control \
     -d '{"userId":1,"control":"move-paddle-up"}'
 
 curl -X GET http://localhost:3000/api/match/<MATCH_ID>/state
+
+# API testing
+
+The file `test/api/api.http` uses placeholders for the base URL and authentication token.
+
+- Replace `@baseUrl` with the URL of your deployed service (for example, `https://<cloud-run-service-url>`) or configure it via an environment variable supported by your HTTP client.
+- Run the **Login** request to store the JWT from the response cookies; subsequent requests automatically include `Cookie: token={{token}}`.
+

--- a/README.md
+++ b/README.md
@@ -50,10 +50,17 @@ curl -X POST http://localhost:3000/api/match/<MATCH_ID>/control \
 
 curl -X GET http://localhost:3000/api/match/<MATCH_ID>/state
 
+# Deployment
+
+The application is available on Google Cloud Run:
+
+- Frontend: https://transcendence-web-923872734712.europe-west6.run.app
+- Backend/API: https://transcendence-back-923872734712.europe-west6.run.app
+
 # API testing
 
-The file `test/api/api.http` uses placeholders for the base URL and authentication token.
+The file `test/api/api.http` targets the deployed backend.
 
-- Replace `@baseUrl` with the URL of your deployed service (for example, `https://<cloud-run-service-url>`) or configure it via an environment variable supported by your HTTP client.
+- `@baseUrl` is set to `https://transcendence-back-923872734712.europe-west6.run.app`.
 - Run the **Login** request to store the JWT from the response cookies; subsequent requests automatically include `Cookie: token={{token}}`.
 

--- a/test/api/api.http
+++ b/test/api/api.http
@@ -2,9 +2,8 @@
 # Settings
 # ============================================================================
 
-@baseUrl = http://localhost:3000
-### Paste your token here after login
-@token = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwidXNlcm5hbWUiOiJhMSIsImlhdCI6MTc1MzEyNDI0NywiZXhwIjoxNzUzMTI3ODQ3fQ.mu0plJQYaZgIUn6CeaxkOvLNEIe5kQ1dGxBNZGHq0AA
+@baseUrl = https://<cloud-run-service-url>
+### Run the Login request below to populate the token dynamically
 
 # =============================================================================
 # Users
@@ -31,6 +30,8 @@ Content-Type: application/json
   "username": "{{username}}",
   "password": "{{password}}"
 }
+
+> {% client.global.set('token', response.cookies.token); %}
 
 ### Get all users
 GET {{baseUrl}}/api/user/all-users

--- a/test/api/api.http
+++ b/test/api/api.http
@@ -2,7 +2,7 @@
 # Settings
 # ============================================================================
 
-@baseUrl = https://<cloud-run-service-url>
+@baseUrl = https://transcendence-back-923872734712.europe-west6.run.app
 ### Run the Login request below to populate the token dynamically
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- replace local base URL and hardcoded JWT with placeholders in `test/api/api.http`
- add script to capture token from login response
- document base URL and token setup in README

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b6c6a9c1c08332b29559db33813155